### PR TITLE
Usar '/usr/bin/env python3' en lugar de '/usr/bin/python3'

### DIFF
--- a/dcubabot.py
+++ b/dcubabot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # STL imports

--- a/deletablecommandhandler.py
+++ b/deletablecommandhandler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from telegram.ext import CommandHandler

--- a/errors.py
+++ b/errors.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 

--- a/install.py
+++ b/install.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from pony.orm import *

--- a/invitacionMail.py
+++ b/invitacionMail.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from models import *
 init_db("dcubabot.sqlite3")

--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from pony.orm import *

--- a/orga2Utils.py
+++ b/orga2Utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Local imports

--- a/river.py
+++ b/river.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # STL imports


### PR DESCRIPTION
Esta es la forma portable de encontrar dónde está el intérprete.
MacOS, por ejemplo, no lo tiene en '/usr/bin'.