### PR TITLE
Cast error code to str

### DIFF
--- a/campus.py
+++ b/campus.py
@@ -22,7 +22,7 @@ def is_campus_up():
     except requests.exceptions.ConnectionError:
         msg = "Hubo un error de conexión, debe estar caído. Espero no sea época de parciales..."
     except requests.exceptions.HTTPError:
-        msg = "Recibí una respuesta del campus con error. " + response.status_code + ": " + response.reason
+        msg = "Recibí una respuesta del campus con error. " + str(response.status_code) + ": " + response.reason
     except:
         msg = "Hubo un error y no tengo idea de qué fue. Rezale a Shannon."
 

--- a/campus.py
+++ b/campus.py
@@ -22,7 +22,7 @@ def is_campus_up():
     except requests.exceptions.ConnectionError:
         msg = "Hubo un error de conexión, debe estar caído. Espero no sea época de parciales..."
     except requests.exceptions.HTTPError:
-        msg = "Recibí una respuesta del campus con error. " + str(response.status_code) + ": " + response.reason
+        msg = f"Recibí una respuesta del campus con error. {response.status_code}: {response.reason}"
     except:
         msg = "Hubo un error y no tengo idea de qué fue. Rezale a Shannon."
 


### PR DESCRIPTION
Cuando el campus esta caido y cae en el `HTTPError` el `status_code` es un int, cuando intentas concatenarlo con el mensaje te da el error: 

```
msg = "Recibí una respuesta del campus con error. " + response.status_code + ": " + response.reason
TypeError: can only concatenate str (not "int") to str
``` 

Solo hay que castearlo a str para que funcione.